### PR TITLE
Move sami to development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "sellerlabs/research-php",
   "description": "PHP client for SellerLabs' Research API",
+  "version": "0.0.11",
   "require": {
     "guzzlehttp/guzzle": "4.1.*",
     "nesbot/Carbon": "*"

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
   "description": "PHP client for SellerLabs' Research API",
   "require": {
     "guzzlehttp/guzzle": "4.1.*",
-    "nesbot/Carbon": "*",
-    "sami/sami": "~3.0"
+    "nesbot/Carbon": "*"
   },
   "require-dev": {
     "mockery/mockery": "~0.9",
-    "phpunit/phpunit": "*"
+    "phpunit/phpunit": "*",
+    "sami/sami": "~3.0"
   },
   "conflict": {
     "sellerlabs/modernmws-php": "*",


### PR DESCRIPTION
It conflicts with Laravel4 and really is only used on development and isn't needed for production stuff.