### PR TITLE
Return empty array for `parents` and `children` if receives malformed…

### DIFF
--- a/src/SellerLabs/Research/Entities/RelationshipBag.php
+++ b/src/SellerLabs/Research/Entities/RelationshipBag.php
@@ -38,8 +38,16 @@ class RelationshipBag
      */
     public function __construct(array $relationships)
     {
-        $this->setParents(Arr::dotGet($relationships, 'parents'));
-        $this->setChildren(Arr::dotGet($relationships, 'children'));
+        $parents = Arr::dotGet($relationships, 'parents', []);
+        $children = Arr::dotGet($relationships, 'children', []);
+
+        if (is_array($parents) && !$this->isAssoc($parents)) {
+            $this->setParents($parents);
+        }
+
+        if (is_array($children) && !$this->isAssoc($children)) {
+            $this->setChildren($children);
+        }
     }
 
     /**
@@ -76,5 +84,22 @@ class RelationshipBag
     public function getParents()
     {
         return $this->parents;
+    }
+
+    /**
+     * Determines if an array is an associative array.
+     *
+     * @param $array
+     *
+     * @return bool
+     */
+    public function isAssoc(array $array)
+    {
+        return count(
+            array_filter(
+                array_keys($array),
+                'is_string'
+            )
+        ) > 0;
     }
 }

--- a/tests/SellerLabs/Research/Entities/RelationshipBagTest.php
+++ b/tests/SellerLabs/Research/Entities/RelationshipBagTest.php
@@ -22,6 +22,54 @@ use Tests\SellerLabs\Support\TestCase;
  */
 class RelationshipBagTest extends TestCase
 {
+    /**
+     * Invalid parents relationships.
+     *
+     * The array returned by accessing the key `parents` is
+     * an associative array (not sequential).
+     *
+     * @return array
+     */
+    protected function invalidParentsRelationships()
+    {
+        return [
+            "parents" => [
+                "Identifiers" => [
+                    "asin" => null,
+                    "marketplaceasin" => [
+                        "MarketplaceId" => "ATVPDKIKX0DER",
+                        "ASIN" => "B00S16RNNC",
+                    ]
+                ],
+                "ns2:Color" => "Pink"
+            ]
+        ];
+    }
+
+    /**
+     * Invalid children relationships.
+     *
+     * The array returned by accessing the key `children` is
+     * associative array (not sequential).
+     *
+     * @return array
+     */
+    protected function invalidChildrenRelationships()
+    {
+        return [
+            "children" => [
+                "Identifiers" => [
+                    "asin" => null,
+                    "marketplaceasin" => [
+                        "MarketplaceId" => "ATVPDKIKX0DER",
+                        "ASIN" => "B00S16RNNC",
+                    ]
+                ],
+                "ns2:Color" => "Pink"
+            ]
+        ];
+    }
+
     public function testConstruct()
     {
         $relationships = "{
@@ -71,5 +119,57 @@ class RelationshipBagTest extends TestCase
             $bag->getParents()[0]->getProperties()
         );
 
+    }
+
+    public function testChildrenWhenMalformed()
+    {
+        $bag = new RelationshipBag(
+            $this->invalidChildrenRelationships()
+        );
+
+        $this->assertEquals(
+            [],
+            $bag->getChildren()
+        );
+    }
+
+    public function testParentsWhenMalformed()
+    {
+        $bag = new RelationshipBag(
+            $this->invalidParentsRelationships()
+        );
+
+        $this->assertEquals(
+            [],
+            $bag->getParents()
+        );
+    }
+
+    public function testChildrenWhenMalformedNotArray()
+    {
+        $bag = new RelationshipBag(
+            [
+                "children" => 'notAnArray'
+            ]
+        );
+
+        $this->assertEquals(
+            [],
+            $bag->getParents()
+        );
+    }
+
+    public function testParentWhenMalformedNotArray()
+    {
+        $bag = new RelationshipBag(
+            [
+                "parents" => 'notAnArray'
+            ]
+        );
+
+        $this->assertEquals(
+            [],
+            $bag->getParents()
+        );
     }
 }


### PR DESCRIPTION
… data.

Sometimes, MWS webservice fails and returns a http request (with status of 200)
and some of the data is malformed.

This commit returns an empty array for `children` and `parents` when the data is
malformed. Malformed data returns an associative array (not a sequential) array.

NOTE: This is NOT a great fix. The correct fix would be fixing MWS. This is
merely a bandaid.